### PR TITLE
Fixed payload message _TZE200_z1tyspqw,_TZE200_bvrlmajk

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4964,7 +4964,7 @@ const definitions: DefinitionWithExtend[] = [
             e.min_temperature(),
             e.position(),
             e.window_detection(),
-            e.binary('window', ea.STATE, 'CLOSED', 'OPEN').withDescription('Window status closed or open '),
+            e.binary('window', ea.STATE, 'CLOSE', 'OPEN').withDescription('Window status closed or open '),
             e.binary('alarm_switch', ea.STATE, 'ON', 'OFF').withDescription('Thermostat in error state'),
             e
                 .climate()


### PR DESCRIPTION
payload message for closed window state on thermostatic radiator valves _TZE200_z1tyspqw and _TZE200_bvrlmajk was inconsistent. Should be "CLOSE", not "CLOSED".
This inconsistency causes cooperating SW (in my case OpenHAB 4.2.2) to raise warning often repeating and fullfiling the log and disables the readout of the state.
I have both mentioned valves. The definitions if also used for models _TZE200_a4bpgplm, _TZE200_dv8abrrz, I do not have them and cannot check it. I have also couple of other valves of other types and all of them use "CLOSE" payload.